### PR TITLE
Add ESLint's `sort-imports` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,8 @@ module.exports = {
 		"@typescript-eslint/no-non-null-assertion": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"no-restricted-globals": "off",
+
+		"sort-imports": ["warn", { ignoreDeclarationSort: true, ignoreCase: true }],
 	},
 	ignorePatterns: ["src/img/**", "*.css", "*.scss", "gulpfile.js", "publish/**", "src/lib/generated/**"],
 };

--- a/src/elements/addon-visibility-selector.tsx
+++ b/src/elements/addon-visibility-selector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./addon-visibility-selector.scss";
 import FlaskImage from "../img/flask.svg";
-import { LocalizableProps, Locales, SimpleLocale, createLocalizer } from "../lib/localize";
+import { createLocalizer, Locales, LocalizableProps, SimpleLocale } from "../lib/localize";
 
 interface Props extends LocalizableProps {
 	active: boolean;

--- a/src/elements/netspeak-corpus-selector.tsx
+++ b/src/elements/netspeak-corpus-selector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "./netspeak-corpus-selector.scss";
-import { LocalizableProps, Locales, SimpleLocale, createLocalizer } from "../lib/localize";
+import { createLocalizer, Locales, LocalizableProps, SimpleLocale } from "../lib/localize";
 import { Corpus } from "../lib/netspeak";
 
 interface Props extends LocalizableProps {

--- a/src/elements/netspeak-example-queries.tsx
+++ b/src/elements/netspeak-example-queries.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { LocalizableProps, Locales, SimpleLocale, createLocalizer } from "../lib/localize";
+import { createLocalizer, Locales, LocalizableProps, SimpleLocale } from "../lib/localize";
 import "./netspeak-example-queries.scss";
 import NetspeakQueryText from "./netspeak-query-text";
 

--- a/src/elements/netspeak-result-list.tsx
+++ b/src/elements/netspeak-result-list.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { LocalizableProps, Locales, SimpleLocale, createLocalizer } from "../lib/localize";
-import { Phrase, WordTypes, Word } from "../lib/netspeak";
-import { Snippet, getPhraseRegex, LookaheadSnippetSupplier } from "../lib/snippets";
-import { optional, LoadingState, url, delay } from "../lib/util";
+import { createLocalizer, Locales, LocalizableProps, SimpleLocale } from "../lib/localize";
+import { Phrase, Word, WordTypes } from "../lib/netspeak";
+import { getPhraseRegex, LookaheadSnippetSupplier, Snippet } from "../lib/snippets";
+import { delay, LoadingState, optional, url } from "../lib/util";
 import LoadMoreButton from "./load-more-button";
 import "./netspeak-result-list.scss";
 import TransparentButton from "./transparent-button";

--- a/src/lib/netspeak.ts
+++ b/src/lib/netspeak.ts
@@ -1,9 +1,9 @@
 import { Metadata } from "grpc-web";
 import { NetspeakServiceClient } from "./generated/NetspeakServiceServiceClientPb";
 import {
-	SearchRequest,
-	PhraseConstraints,
 	CorporaRequest,
+	PhraseConstraints,
+	SearchRequest,
 	Phrase as ServicePhrase,
 } from "./generated/NetspeakService_pb";
 import { LRUCache } from "./lru-cache";

--- a/src/lib/snippets.ts
+++ b/src/lib/snippets.ts
@@ -1,4 +1,4 @@
-import { textContent, normalizeSpaces, constructQueryParams } from "./util";
+import { constructQueryParams, normalizeSpaces, textContent } from "./util";
 
 export interface Snippet {
 	/**

--- a/src/page-elements/netspeak-footer.tsx
+++ b/src/page-elements/netspeak-footer.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { Link } from "gatsby";
 import "./netspeak-footer.scss";
 import {
-	LocalizableProps,
-	Locales,
-	SimpleLocale,
 	createLocalizer,
-	SupportedLanguage,
+	Locales,
+	LocalizableProps,
 	setCurrentLang,
+	SimpleLocale,
+	SupportedLanguage,
 } from "../lib/localize";
 
 export default function NetspeakFooter(props: LocalizableProps): JSX.Element {

--- a/src/page-elements/netspeak-header.tsx
+++ b/src/page-elements/netspeak-header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "./netspeak-header.scss";
-import { Locales, SimpleLocale, createLocalizer, LocalizableProps } from "../lib/localize";
+import { createLocalizer, Locales, LocalizableProps, SimpleLocale } from "../lib/localize";
 import { Link } from "gatsby";
 
 export default function NetspeakHeader(props: LocalizableProps): JSX.Element {


### PR DESCRIPTION
As mentioned in #32, I added the `sort-imports` rule to sort import members. This will hopefully minimize diffs in the future.